### PR TITLE
Use new identification endpoints

### DIFF
--- a/dist/UseIdAPI.js
+++ b/dist/UseIdAPI.js
@@ -13,7 +13,7 @@ class UseIdAPI {
         });
         this.domain = domain;
         this.widgetSrc = `${domain}/widget.js`;
-        this.apiBaseUrl = `${domain}/api/v1/identification/sessions`;
+        this.apiBaseUrl = `${domain}/api/v1/identifications`;
     }
     async startSession() {
         const response = await axios_1.default.post(this.apiBaseUrl);

--- a/src/UseIdAPI.test.ts
+++ b/src/UseIdAPI.test.ts
@@ -23,7 +23,7 @@ describe('startSession()', () => {
   it('should start session and return tcTokenUrl', async () => {
     const response = await useIdAPI.startSession();
     expect(response).toEqual({ tcTokenUrl });
-    expect(useIdAPI.api.getUri()).toEqual(`${useIdAPI.domain}/api/v1/identification/sessions`);
+    expect(useIdAPI.api.getUri()).toEqual(`${useIdAPI.domain}/api/v1/identifications`);
     expect(axiosPost).toHaveBeenCalledWith('/');
   });
 });

--- a/src/UseIdAPI.ts
+++ b/src/UseIdAPI.ts
@@ -12,7 +12,7 @@ export class UseIdAPI {
   constructor(apiKey: string, domain: string) {
     this.domain = domain;
     this.widgetSrc = `${domain}/widget.js`;
-    this.apiBaseUrl = `${domain}/api/v1/identification/sessions`;
+    this.apiBaseUrl = `${domain}/api/v1/identifications`;
     this.api = axios.create({
       baseURL: this.apiBaseUrl,
       headers: {


### PR DESCRIPTION
This uses the new endpoints provided from useID. We can merge this after [the new endpoints have been provided](https://github.com/digitalservicebund/useid-backend-service/pull/249).